### PR TITLE
Reduce dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>com.vaadin</groupId>
 			<!-- Replace artifactId with vaadin-core to use only free components -->
-			<artifactId>vaadin</artifactId>
+			<artifactId>vaadin-core</artifactId>
 			<exclusions>
 				<!-- Webjars are only needed when running in Vaadin 13 compatibility mode in V14.
 					 Your add-on can support npm in the same version mode and V13 compatiblity mode at the same time,


### PR DESCRIPTION
Hey Alejandro,

I guess the dependency to `com.vaadin:vaadin` is by accident, as you licenced this little but handy addon under Apache-2 :-) At least `mvn jetty:run` works also with `com.vaadin:vaadin-core` as expected.

Just wondered why adding `pdf-browser` leaded to several dependencies added in my `package.json`:

<img width="659" alt="grafik" src="https://user-images.githubusercontent.com/1956979/106036592-d606c300-60d5-11eb-9a27-b7b15cf0e614.png">

In the meanwhile a simple exclusion can be a workaround. E. g. in `build.gradle`:
```groovy
    implementation("org.vaadin.alejandro:pdf-browser:3.0.1") {
        exclude group: "com.vaadin"
    }
```